### PR TITLE
fix single file styles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 - "8"
 - "10"
 language: node_js
-script: "npm test:ci"
+script: "npm run test:ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 node_js:
 - "4"
-- "5"
 - "6"
-- "7"
 - "8"
+- "10"
 language: node_js
-script: "npm test"
+script: "npm test:ci"

--- a/lasso-marko-plugin.js
+++ b/lasso-marko-plugin.js
@@ -95,10 +95,15 @@ module.exports = function(lasso, config) {
                 });
             } else {
                 if (meta.deps) {
-                    dependencies = dependencies.concat(meta.deps.map(depPath => ({
-                        type: 'require',
-                        path: require.resolve(this.resolvePath(depPath, nodePath.dirname(this.path)))
-                    })));
+                    dependencies = dependencies.concat(meta.deps.map(dep => (
+                        dep.code ? {
+                            type: dep.type,
+                            code: dep.code 
+                        } : {
+                            type: dep.includes(':') ? dep.slice(0, dep.indexOf(':')) : 'require',
+                            path: this.resolvePath(dep, nodePath.dirname(this.path))
+                        }
+                    )));
                 }
 
                 if (meta.tags) {
@@ -106,7 +111,7 @@ module.exports = function(lasso, config) {
                     // any tags that are used by this template
                     dependencies = dependencies.concat(meta.tags.map(tagPath => ({
                         type: 'marko-dependencies',
-                        path: require.resolve(this.resolvePath(tagPath, nodePath.dirname(this.path)))
+                        path: this.resolvePath(tagPath, nodePath.dirname(this.path))
                     })));
                 }
             }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/lasso-js/lasso-marko.git"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha --ui bdd --reporter spec ./test"
+    "test": "mocha --ui bdd --reporter spec --timeout 10000 ./test",
+    "test:ci": "vertest --epilogue=verbose"
   },
   "author": "Patrick Steele-Idem <pnidem@gmail.com>",
   "contributors": [
@@ -23,10 +24,14 @@
     "chai": "^3.5.0",
     "lasso": "^3.1.4",
     "marko": "^4.3.1",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "vertest": "^1.0.1"
   },
-  "peerDependencies": {},
-  "license": "Apache License v2.0",
+  "peerDependencies": {
+    "lasso": "^3 || ^2.11",
+    "marko": "^4.7"
+  },
+  "license": "Apache-2.0",
   "bin": {},
   "main": "./lasso-marko-plugin.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
   "devDependencies": {
     "chai": "^3.5.0",
-    "lasso": "^2.0.0",
+    "lasso": "^3.1.4",
     "marko": "^4.3.1",
     "mocha": "^3.2.0"
   },

--- a/test/fixtures/project1/components/hello.marko
+++ b/test/fixtures/project1/components/hello.marko
@@ -1,0 +1,7 @@
+style {
+    span {
+        color:red;
+    }
+}
+
+<span>Hello</span>

--- a/test/fixtures/project1/simple.browser.json
+++ b/test/fixtures/project1/simple.browser.json
@@ -1,5 +1,5 @@
 {
     "dependencies": [
-        "simple.marko"
+        "./test.js"
     ]
 }

--- a/test/fixtures/project1/simple.marko
+++ b/test/fixtures/project1/simple.marko
@@ -1,3 +1,7 @@
+style {
+  div { color:blue }
+}
+
 <div>
-  Hello ${input.name}!
+  <hello/> ${input.name}!
 </div>

--- a/test/fixtures/project1/test.js
+++ b/test/fixtures/project1/test.js
@@ -1,0 +1,1 @@
+console.log('TEST');

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,20 @@ var fs = require('fs');
 var markoPlugin = require('../'); // Load this module just to make sure it works
 var lasso = require('lasso');
 
+var config = {
+    fileWriter: {
+        fingerprintsEnabled: false,
+        outputDir: nodePath.join(__dirname, 'static')
+    },
+    bundlingEnabled: true,
+    require: {
+        includeClient: false
+    },
+    plugins: [
+        markoPlugin
+    ]
+};
+
 describe('lasso-marko' , function() {
 
     beforeEach(function(done) {
@@ -20,76 +34,86 @@ describe('lasso-marko' , function() {
         done();
     });
 
-    it('should render a simple marko dependency', function() {
-        var myLasso = lasso.create({
-            fileWriter: {
-                fingerprintsEnabled: false,
-                outputDir: nodePath.join(__dirname, 'static')
-            },
-            bundlingEnabled: true,
-            plugins: [
-                {
-                    plugin: markoPlugin,
-                    config: {
-
-                    }
-                },
-                {
-                    plugin: 'lasso-require',
-                    config: {
-                        includeClient: false
-                    }
-                }
-            ]
-        });
+    it('should bundle a simple marko dependency tree', function() {
+        var myLasso = lasso.create(config);
 
         return myLasso.lassoPage({
-            name: 'testPage',
+            name: 'basic',
             dependencies: [
                 nodePath.join(__dirname, 'fixtures/project1/simple.marko')
             ],
             from: nodePath.join(__dirname, 'fixtures/project1')
         }).then((lassoPageResult) => {
-            var output = fs.readFileSync(nodePath.join(__dirname, 'static/testPage.js'), {encoding: 'utf8'});
-            expect(output).to.contain("simple.marko");
-            expect(output).to.contain("input.name");
+            var JS = fs.readFileSync(nodePath.join(__dirname, 'static/basic.js'), {encoding: 'utf8'});
+            var CSS = fs.readFileSync(nodePath.join(__dirname, 'static/basic.css'), {encoding: 'utf8'});
+            expect(JS).to.contain("simple.marko");
+            expect(JS).to.contain("input.name");
+            expect(JS).to.contain("TEST");
+            expect(CSS).to.contain("blue");
+            expect(CSS).to.contain("red");
             return lasso.flushAllCaches();
         });
     });
 
-    it('should render a simple marko dependency that uses require', function() {
-        var myLasso = lasso.create({
-            fileWriter: {
-                fingerprintsEnabled: false,
-                outputDir: nodePath.join(__dirname, 'static')
-            },
-            bundlingEnabled: true,
-            plugins: [
-                {
-                    plugin: markoPlugin,
-                    config: {
-
-                    }
-                },
-                {
-                    plugin: 'lasso-require',
-                    config: {
-                        includeClient: false
-                    }
-                }
-            ]
-        });
+    it('should bundle a simple marko dependency tree that uses require', function() {
+        var myLasso = lasso.create(config);
 
         return myLasso.lassoPage({
-            name: 'testPage',
+            name: 'require',
             dependencies: [
                 'require: ./simple.marko'
             ],
             from: nodePath.join(__dirname, 'fixtures/project1')
         }).then((lassoPageResult) => {
-            var output = fs.readFileSync(nodePath.join(__dirname, 'static/testPage.js'), {encoding: 'utf8'});
-            expect(output).to.contain("simple.marko");
-            expect(output).to.contain("input.name");
+            var JS = fs.readFileSync(nodePath.join(__dirname, 'static/require.js'), {encoding: 'utf8'});
+            var CSS = fs.readFileSync(nodePath.join(__dirname, 'static/require.css'), {encoding: 'utf8'});
+            expect(JS).to.contain("simple.marko");
+            expect(JS).to.contain("input.name");
+            expect(JS).to.contain("TEST");
+            expect(CSS).to.contain("blue");
+            expect(CSS).to.contain("red");
+            return lasso.flushAllCaches();
+        });
+    });
+
+    it('should bundle a simple marko dependency tree that uses dependencies', function() {
+        var myLasso = lasso.create(config);
+
+        return myLasso.lassoPage({
+            name: 'dependencies',
+            dependencies: [
+                'marko-dependencies: ./simple.marko'
+            ],
+            from: nodePath.join(__dirname, 'fixtures/project1')
+        }).then((lassoPageResult) => {
+            var JS = fs.readFileSync(nodePath.join(__dirname, 'static/dependencies.js'), {encoding: 'utf8'});
+            var CSS = fs.readFileSync(nodePath.join(__dirname, 'static/dependencies.css'), {encoding: 'utf8'});
+            expect(JS).to.not.contain("simple.marko");
+            expect(JS).to.not.contain("input.name");
+            expect(JS).to.contain("TEST");
+            expect(CSS).to.contain("blue");
+            expect(CSS).to.contain("red");
+            return lasso.flushAllCaches();
+        });
+    });
+
+    it('should bundle a simple marko dependency tree that uses hydrate', function() {
+        var myLasso = lasso.create(config);
+
+        return myLasso.lassoPage({
+            name: 'hydrate',
+            dependencies: [
+                'marko-hydrate: ./simple.marko'
+            ],
+            from: nodePath.join(__dirname, 'fixtures/project1')
+        }).then((lassoPageResult) => {
+            var JS = fs.readFileSync(nodePath.join(__dirname, 'static/hydrate.js'), {encoding: 'utf8'});
+            var CSS = fs.readFileSync(nodePath.join(__dirname, 'static/hydrate.css'), {encoding: 'utf8'});
+            expect(JS).to.not.contain("simple.marko");
+            expect(JS).to.not.contain("input.name");
+            expect(JS).to.contain("TEST");
+            expect(CSS).to.contain("blue");
+            expect(CSS).to.contain("red");
             return lasso.flushAllCaches();
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,8 @@ describe('lasso-marko' , function() {
     });
 
     it('should bundle a simple marko dependency tree that uses dependencies', function() {
+        if (require('lasso/package').version[0] < 3) this.skip();
+        
         var myLasso = lasso.create(config);
 
         return myLasso.lassoPage({
@@ -98,6 +100,8 @@ describe('lasso-marko' , function() {
     });
 
     it('should bundle a simple marko dependency tree that uses hydrate', function() {
+        if (require('lasso/package').version[0] < 3) this.skip();
+
         var myLasso = lasso.create(config);
 
         return myLasso.lassoPage({


### PR DESCRIPTION
Inline styles did not work for `marko-dependencies:` and `marko-hydrate:`

```marko
style {
   .body::after {
      content: "styles in template.marko now work";
   }
}

<div/>
```